### PR TITLE
python3: Fix "TypeError: 'dict_keys' object is not subscriptable" 

### DIFF
--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -23,5 +23,5 @@ where
 For testing the example type:
 
 ```bash
-MaTiSSe.py -i getting_started.md --indented --toc-at-subsec-beginning 2
+MaTiSSe.py -i getting_started.md --toc-at-subsec-beginning 2
 ```

--- a/src/main/python/matisse/theme.py
+++ b/src/main/python/matisse/theme.py
@@ -148,7 +148,7 @@ class Theme(object):
           found = False
           for mycss in my_element:
             if isinstance(css, dict):
-              if css.keys()[0] in mycss:
+              if list(css.keys())[0] in mycss:
                 found = True
             elif css in mycss:
               found = True


### PR DESCRIPTION
I installed [MaTiSSe from pypi tarball](https://pypi.org/project/MaTiSSe.py/), applied last [`Fix issue with Python 3`](https://github.com/szaghi/MaTiSSe/commit/ad05d668a0fbdd4dcc889ce37707b4a459542bd3) patch for MaTiSSe and then execution of  command `$ MaTiSSe.py -i getting_started.md --toc-at-subsec-beginning 2` within getting_stated example directory results in error:
```
Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.9/MaTiSSe.py", line 5, in <module>
    main()
  File "/usr/lib/python3.9/site-packages/matisse/matisse.py", line 164, in main
    make_presentation(config=config, source=source, output=output)
  File "/usr/lib/python3.9/site-packages/matisse/matisse.py", line 117, in make_presentation
    presentation.parse(config=config, source=source)
  File "/usr/lib/python3.9/site-packages/matisse/presentation.py", line 366, in parse
    slide.overtheme.copy_from(other=self.theme)
  File "/usr/lib/python3.9/site-packages/matisse/theme.py", line 163, in copy_from
    append_css(my_element=self.toc_chapter_emph, other_element=other.toc_chapter_emph)
  File "/usr/lib/python3.9/site-packages/matisse/theme.py", line 151, in append_css
    if css.keys()[0] in mycss:
TypeError: 'dict_keys' object is not subscriptable
```

The offered patch should fix this error.


Also the `--indented` option is dropped from `getting_stated/README.md` example as this option was purged out early from MaTiSSe.
